### PR TITLE
Updates repository reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ metadata:
   name: kubewarden-example
   namespace: fleet-local
 spec:
-  repo: https://github.com/viccuad/kubewarden-fleet
+  repo: https://github.com/kubewarden/kubewarden-fleet
   branch: main
   paths:
   - helm-kubewarden/


### PR DESCRIPTION
The repository in the fleet resource definition was pointing to the wrong repository. This commit fixes that.

