### PR TITLE
Use contrib image for otel collector

### DIFF
--- a/open-telemetry/fleet.yaml
+++ b/open-telemetry/fleet.yaml
@@ -13,6 +13,10 @@ helm:
   chart: opentelemetry-operator
   version: 0.75.1
   repo: https://open-telemetry.github.io/opentelemetry-helm-charts
+  values:
+    manager:
+      collectorImage:
+        repository: "otel/opentelemetry-collector-contrib"
 
 labels:
   app: open-telemetry


### PR DESCRIPTION
Currently the fleet example does not work, this fixes:

> ErrApplied(1) [Cluster fleet-default/homelab: execution error at (opentelemetry-operator/templates/NOTES.txt:2:3): [ERROR] 'manager.collectorImage.repository' must be set. See https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-operator/UPGRADING.md for instructions.]