### PR TITLE
PSA and Fleet Diff fixes

### DIFF
--- a/cert-manager/fleet.yaml
+++ b/cert-manager/fleet.yaml
@@ -18,3 +18,17 @@ helm:
 
 labels:
   app: cert-manager
+
+# Patches needed for Fleet
+diff:
+  comparePatches:
+  - apiVersion: admissionregistration.k8s.io/v1
+    kind: MutatingWebhookConfiguration
+    name: cert-manager-webhook
+    operations:
+    - {"op": "remove", "path":"/webhooks/0"}
+  - apiVersion: admissionregistration.k8s.io/v1
+    kind: ValidatingWebhookConfiguration
+    name: cert-manager-webhook
+    operations:
+    - {"op": "remove", "path":"/webhooks/0"}

--- a/kubewarden/admission-controller/fleet.yaml
+++ b/kubewarden/admission-controller/fleet.yaml
@@ -1,6 +1,14 @@
 # https://fleet.rancher.io/ref-fleet-yaml
 defaultNamespace: cattle-kubewarden-system
 
+namespaceLabels:
+  pod-security.kubernetes.io/enforce: baseline
+  pod-security.kubernetes.io/enforce-version: latest
+  pod-security.kubernetes.io/audit: baseline
+  pod-security.kubernetes.io/audit-version: latest
+  pod-security.kubernetes.io/warn: baseline
+  pod-security.kubernetes.io/wrn-version: latest
+
 helm:
   version: "*-0" # 6.0.0-rc.2
   releaseName: rancher-admission-controller
@@ -44,7 +52,6 @@ diff:
     - apiVersion: admissionregistration.k8s.io/v1
       kind: MutatingWebhookConfiguration
       name: kubewarden-controller-mutating-webhook-configuration
-      jsonPointers:
       operations:
         - { "op": "remove", "path": "/webhooks" }
 

--- a/rancher-monitoring/app/fleet.yaml
+++ b/rancher-monitoring/app/fleet.yaml
@@ -80,10 +80,14 @@ diff:
   - apiVersion: admissionregistration.k8s.io/v1
     kind: MutatingWebhookConfiguration
     name: rancher-monitoring-admission
-    operations:
-    - {"op": "remove", "path":"/webhooks/0"}
+    jsonPointers:
+      - /webhooks/0/clientConfig/caBundle
+      - /webhooks/0/rules
   - apiVersion: admissionregistration.k8s.io/v1
     kind: ValidatingWebhookConfiguration
     name: rancher-monitoring-admission
-    operations:
-    - {"op": "remove", "path":"/webhooks/0"}
+    jsonPointers:
+      - /webhooks/0/clientConfig/caBundle
+      - /webhooks/0/rules
+      - /webhooks/1/clientConfig/caBundle
+      - /webhooks/1/rules


### PR DESCRIPTION
## Description

Redeployed from scratch and fixed the issue.
1. The namespace cattle-kubewarden-system needs to use the baseline PSA
2. Cert-Manager and Rancher Monitoring needed Fleet Diffs 